### PR TITLE
:sparkles: Remote terraform state

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,6 +10,25 @@ resource "random_id" "bucket_suffix" {
   byte_length = 4
 }
 
+resource "google_storage_bucket" "terraform_state" {
+  name          = "nlcli-terraform-state-${var.project_id}"
+  location      = var.region
+  storage_class = "STANDARD"
+  project       = var.project_id
+
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+
+  labels = {
+    environment = var.environment
+    project     = "nlcli-wizard"
+    purpose     = "terraform-state"
+  }
+}
+
 resource "google_storage_bucket" "nlcli_ml_training_base" {
   name          = local.bucket_name_base
   location      = var.region

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -12,11 +12,10 @@ terraform {
     }
   }
 
-  # Uncomment to use remote state in GCS
-  # backend "gcs" {
-  #   bucket = "your-terraform-state-bucket"
-  #   prefix = "nlcli-wizard/state"
-  # }
+  backend "gcs" {
+    bucket = "nlcli-terraform-state-nl-cli"
+    prefix = "nlcli-wizard/state"
+  }
 }
 
 provider "google" {


### PR DESCRIPTION
The Terraform state is now stored in its own bucket on GCP to ensure 'locking', i.e. that two engineers cannot make conflicting changes at the same time. If one engineer is trying to push changes while another engineer already is, he or she will get an error plus a message showing who is currently working on the infra.